### PR TITLE
Assigned variable to do_plugin

### DIFF
--- a/start.py
+++ b/start.py
@@ -53,6 +53,7 @@ def main(arguments):
         script_path = os.path.join(arguments['PATH_TO_BRO_SRC'], "scripts/base/protocols", arguments['NAME'].lower())
         mkdir(pac_path)
         mkdir(script_path)
+        do_plugin = False
 
     # # 1. C stuff
 


### PR DESCRIPTION
I was running into issues with this on my local box so I just implemented a quick change to help. 

Error I was receiving:

Traceback (most recent call last):
  File "start.py", line 177, in <module>
    main(arguments)
  File "start.py", line 59, in main
    if do_plugin:
UnboundLocalError: local variable 'do_plugin' referenced before assignment

Thanks!